### PR TITLE
Use ephemeral ports and register with an ALB Target Group

### DIFF
--- a/ContinuousIntegration/CloudFormation/deviceMeasurementsAPICloudFormation.json
+++ b/ContinuousIntegration/CloudFormation/deviceMeasurementsAPICloudFormation.json
@@ -62,78 +62,78 @@
       "Properties" : {
         "UserName" : { "Ref" : "deviceMeasurementsAPIUser" }
       }
-    }
-  },
-  "taskDefinition": {
-    "Type": "AWS::ECS::TaskDefinition",
-    "Properties": {
-      "ContainerDefinitions": [
-        {
-          "Name": "device-measurements-api",
-          "Cpu": "1",
-          "Essential": "true",
-          "Image": { "Fn::Join" :  [ "", [ "docker.io/linn/device-measurements-api:", { "Ref" : "dockerTag" } ]]},
-          "Memory": "300",
-          "PortMappings": [
-            {
-              "ContainerPort": 3000
-            }
-          ],
-          "Environment": [
-            {
-              "Name": "AWS_REGION",
-              "Value": { "Ref": "AWS::Region" }
-            },
-            {
-              "Name": "AWS_ACCESS_KEY_ID",
-              "Value": { "Ref": "deviceMeasurementsAPIAccesskey" }
-            },
-            {
-              "Name": "AWS_SECRET_ACCESS_KEY",
-              "Value": { "Fn::GetAtt": [ "deviceMeasurementsAPIAccesskey", "SecretAccessKey" ] }
-            },
-            {
-              "Name": "DEVICES_TABLE_NAME",
-              "Value": { "Ref": "devicesTableName" }
-            },
-            {
-              "Name": "DEVICES_TOPOLOGY_TABLE_NAME",
-              "Value": { "Ref": "devicesTopologyTableName" }
-            },
-            {
-              "Name": "PRODUCT_DESCRIPTORS_TABLE_NAME",
-              "Value": { "Ref": "productDescriptorsTableName" }
-            },
-            {
-              "Name": "PRODUCT_DESCRIPTORS_TABLE_INDEX",
-              "Value": { "Ref": "productDescriptorsTableIndex" }
-            },
-            {
-              "Name": "NODE_ENV",
-              "Value": "release"
-            },
-            {
-              "Name": "PORT",
-              "Value": "3000"
-            }
-          ]
-        }
-      ]
-    }
-  },
-  "service": {
-    "Type": "AWS::ECS::Service",
-    "Properties" : {
-      "Cluster": { "Ref":"targetCluster" },
-      "DesiredCount": "2",
-      "TaskDefinition" : { "Ref":"taskDefinition" }, "Role": "ecsServiceRole",
-      "LoadBalancers": [
-        {
-          "ContainerName": "device-measurements-api",
-          "ContainerPort": 3000,
-          "TargetGroupArn": { "Ref": "albTargetGroupArn" }
-        }
-      ]
+    },
+    "taskDefinition": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Name": "device-measurements-api",
+            "Cpu": "1",
+            "Essential": "true",
+            "Image": { "Fn::Join" :  [ "", [ "docker.io/linn/device-measurements-api:", { "Ref" : "dockerTag" } ]]},
+            "Memory": "300",
+            "PortMappings": [
+              {
+                "ContainerPort": 3000
+              }
+            ],
+            "Environment": [
+              {
+                "Name": "AWS_REGION",
+                "Value": { "Ref": "AWS::Region" }
+              },
+              {
+                "Name": "AWS_ACCESS_KEY_ID",
+                "Value": { "Ref": "deviceMeasurementsAPIAccesskey" }
+              },
+              {
+                "Name": "AWS_SECRET_ACCESS_KEY",
+                "Value": { "Fn::GetAtt": [ "deviceMeasurementsAPIAccesskey", "SecretAccessKey" ] }
+              },
+              {
+                "Name": "DEVICES_TABLE_NAME",
+                "Value": { "Ref": "devicesTableName" }
+              },
+              {
+                "Name": "DEVICES_TOPOLOGY_TABLE_NAME",
+                "Value": { "Ref": "devicesTopologyTableName" }
+              },
+              {
+                "Name": "PRODUCT_DESCRIPTORS_TABLE_NAME",
+                "Value": { "Ref": "productDescriptorsTableName" }
+              },
+              {
+                "Name": "PRODUCT_DESCRIPTORS_TABLE_INDEX",
+                "Value": { "Ref": "productDescriptorsTableIndex" }
+              },
+              {
+                "Name": "NODE_ENV",
+                "Value": "release"
+              },
+              {
+                "Name": "PORT",
+                "Value": "3000"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "service": {
+      "Type": "AWS::ECS::Service",
+      "Properties" : {
+        "Cluster": { "Ref":"targetCluster" },
+        "DesiredCount": "2",
+        "TaskDefinition" : { "Ref":"taskDefinition" }, "Role": "ecsServiceRole",
+        "LoadBalancers": [
+          {
+            "ContainerName": "device-measurements-api",
+            "ContainerPort": 3000,
+            "TargetGroupArn": { "Ref": "albTargetGroupArn" }
+          }
+        ]
+      }
     }
   }
 }

--- a/ContinuousIntegration/CloudFormation/deviceMeasurementsAPICloudFormation.json
+++ b/ContinuousIntegration/CloudFormation/deviceMeasurementsAPICloudFormation.json
@@ -25,6 +25,10 @@
     "productDescriptorsTableIndex": {
       "Type": "String",
       "Description" : "DynamoDb index of product descriptors"
+    },
+    "albTargetGroupArn": {
+      "Type": "String",
+      "Description": "Target Group ARN for device details api"
     }
   },
   "Resources": {
@@ -72,7 +76,6 @@
           "Memory": "300",
           "PortMappings": [
             {
-              "HostPort": 60300,
               "ContainerPort": 3000
             }
           ],
@@ -122,8 +125,15 @@
     "Type": "AWS::ECS::Service",
     "Properties" : {
       "Cluster": { "Ref":"targetCluster" },
-      "DesiredCount": "1",
-      "TaskDefinition" : {"Ref":"taskDefinition"}
+      "DesiredCount": "2",
+      "TaskDefinition" : { "Ref":"taskDefinition" }, "Role": "ecsServiceRole",
+      "LoadBalancers": [
+        {
+          "ContainerName": "device-measurements-api",
+          "ContainerPort": 3000,
+          "TargetGroupArn": { "Ref": "albTargetGroupArn" }
+        }
+      ]
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ define tag_docker
 	fi
 	@if [ "$(TRAVIS_BRANCH)" = "master" -a "$(TRAVIS_PULL_REQUEST)" = "false" ]; then \
 		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):latest; \
+		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):K$(TRAVIS_BUILD_NUMBER); \
 	fi
 	@if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
 		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):PR_$(TRAVIS_PULL_REQUEST); \


### PR DESCRIPTION
This moves the device-measurements-api service behind an application load balancer. 

Additionally the docker container is tagged with a K when built against master to highlight 'official' releases. 